### PR TITLE
Add EvalArithmetic function to evaluate arithmetic expressions using cmd command

### DIFF
--- a/lib/Run.ahk
+++ b/lib/Run.ahk
@@ -21,6 +21,15 @@ RunWaitOne(command) {
     return OUT
 }
 
+
+/**
+ * Evaluate an arithmetic expression using the `cmd` command.
+ * @param expression {String} - The arithmetic expression to evaluate.
+ * @returns {Buffer|String} - The result of the arithmetic expression.
+ */
+EvalArithmetic(expression) => RunWaitOne(Format('cmd /c "set /a {1}"', expression))
+
+
 /**
  * Run or activate a window.
  * 


### PR DESCRIPTION
This pull request adds the EvalArithmetic function, which allows for the evaluation of arithmetic expressions using the `cmd` command. This function takes an arithmetic expression as input and returns the result of the expression.